### PR TITLE
(version 1.22) If there is active Part container or active Body, put …

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ These parameters are currently (subject to change) supported: minor_diameter=4.8
 The internal_data and external_data list properties define the radius of the ThreadProfile object at the various angles around the circumference.  There are 720 points.  Each point is the x-coordinate of a thread profile sketched on the xz plane. The first element in the list is the x-coordinate at z=1/720 degrees, then z=2/720 degrees, etc.  Don't worry, you don't need to include these parameters.  The default used is for the standard Metric M profile.  When the ThreadProfile is created the data points are used as such: each element is taken, then added to it the minor radius + pitch * element value for the x-coordinate.  To get the y-coordinate we use the current element index / 720.  We use the math.cos() and math.sin() functions, but let's not get too bogged down here.  You can view the source code for more details.<br/>
 
 #### Release notes:<br/>
+* 2019.07.23 (version 1.22)<br/>
+** If there is an active part design body or Part object, add the thread profile to it.
 * 2019.07.23 (version 1.21)<br/>
 ** Change Pitch type from Float to Length
 ** Check if Gui is up before creating view object

--- a/ThreadProfileCmd.py
+++ b/ThreadProfileCmd.py
@@ -29,8 +29,8 @@ __title__   = "ThreadProfile"
 __author__  = "Mark Ganson <TheMarkster>"
 __url__     = "https://github.com/mwganson/ThreadProfile"
 __date__    = "2019.07.23"
-__version__ = "1.21"
-version = 1.21
+__version__ = "1.22"
+version = 1.22
 
 import FreeCAD, FreeCADGui, Part, os, math, re
 from PySide import QtCore, QtGui
@@ -225,6 +225,12 @@ that can be swept along a helix to produce a thread.  Code is based on Draft.mak
         _ViewProviderWire(obj.ViewObject)
         formatObject(obj)
         select(obj)
+        body=FreeCADGui.ActiveDocument.ActiveView.getActiveObject("pdbody")
+        part=FreeCADGui.ActiveDocument.ActiveView.getActiveObject("part")
+        if body:
+            body.Group=body.Group+[obj]
+        elif part:
+            part.Group=part.Group+[obj]
     FreeCAD.ActiveDocument.recompute()
     return obj
 


### PR DESCRIPTION
…the ThreadProfile object in it